### PR TITLE
Changed the exception type name exclusion

### DIFF
--- a/EveryCupShop.WebApi/Program.cs
+++ b/EveryCupShop.WebApi/Program.cs
@@ -45,7 +45,7 @@ try
     Log.Information("Server is running");
     app.Run();
 }
-catch (Exception ex) when (ex.GetType().Name != "StopTheHostException")
+catch (Exception ex) when (ex.GetType().Name != "HostAbortedException")
 {
     Log.Fatal(ex, @"Unhandled exception {ExceptionType}", ex.GetType().Name);
 }


### PR DESCRIPTION
### Checklist
- [x] My code follows the style guide lines of this project
- [x] I have performed a self-review of my code
- [x] My changes don't generate new warnings
- [ ] I have added new tests
- [ ] Is this a new feature

### Problem

The application throws the "HostAbortedException" when migrations is created.

### Solution

This pull request fixes the problem by changing the exception's type name in the exclusion.

### Testing

**Manual Testing:** Tested it manually by creating a new migration